### PR TITLE
Fix file() and raw_input()

### DIFF
--- a/编译器/编译器/Source/Lib/cmd.py
+++ b/编译器/编译器/Source/Lib/cmd.py
@@ -47,6 +47,11 @@ they automatically support Emacs-like command history and editing features.
 
 import string
 
+try:
+    raw_input     # Python 2
+except EOFError:  # Python 3
+    raw_input = input
+
 __all__ = ["Cmd"]
 
 PROMPT = '(Cmd) '

--- a/编译器/编译器/Source/Lib/code.py
+++ b/编译器/编译器/Source/Lib/code.py
@@ -10,6 +10,11 @@ import sys
 import traceback
 from codeop import CommandCompiler, compile_command
 
+try:
+    raw_input     # Python 2
+except EOFError:  # Python 3
+    raw_input = input
+
 __all__ = ["InteractiveInterpreter", "InteractiveConsole", "interact",
            "compile_command"]
 

--- a/编译器/编译器/Source/Lib/pstats.py
+++ b/编译器/编译器/Source/Lib/pstats.py
@@ -1,5 +1,4 @@
 """Class for printing reports on profiled python code."""
-from __future__ import print_function
 
 # Written by James Roskind
 # Based on prior profile module by Sjoerd Mullender...
@@ -20,6 +19,7 @@ from __future__ import print_function
 # either express or implied.  See the License for the specific language
 # governing permissions and limitations under the License.
 
+from __future__ import print_function
 
 import sys
 import os
@@ -27,6 +27,11 @@ import time
 import marshal
 import re
 from functools import cmp_to_key
+
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
 
 __all__ = ["Stats"]
 
@@ -162,7 +167,7 @@ class Stats:
 
     def dump_stats(self, filename):
         """Write the profile data to a file we know how to load back."""
-        f = file(filename, 'wb')
+        f = open(filename, 'wb')
         try:
             marshal.dump(self.stats, f)
         finally:

--- a/编译器/编译器/Source/Lib/site.py
+++ b/编译器/编译器/Source/Lib/site.py
@@ -64,6 +64,11 @@ import os
 import __builtin__
 import traceback
 
+try:
+    raw_input     # Python 2
+except EOFError:  # Python 3
+    raw_input = input
+
 # Prefixes for site-packages; add additional prefixes like /usr/local here
 PREFIXES = [sys.prefix, sys.exec_prefix]
 # Enable per user site-packages directory
@@ -384,7 +389,7 @@ class _Printer(object):
             for filename in self.__files:
                 filename = os.path.join(dir, filename)
                 try:
-                    fp = file(filename, "rU")
+                    fp = open(filename, "rU")
                     data = fp.read()
                     fp.close()
                     break

--- a/编译器/编译器/Source/Lib/types.py
+++ b/编译器/编译器/Source/Lib/types.py
@@ -14,7 +14,6 @@ TypeType = type
 ObjectType = object
 
 IntType = int
-LongType = long
 FloatType = float
 BooleanType = bool
 try:
@@ -24,16 +23,21 @@ except NameError:
 
 StringType = str
 
-# StringTypes is already outdated.  Instead of writing "type(x) in
-# types.StringTypes", you should use "isinstance(x, basestring)".  But
-# we keep around for compatibility with Python 2.2.
-try:
+try:               # Python 2
+    BufferType = buffer
+    FileType = file
+    LongType = long
+    StringTypes = basestring
     UnicodeType = unicode
-    StringTypes = (StringType, UnicodeType)
-except NameError:
+    XRangeType = xrange
+except NameError:  # Python 3
+    from io import IOBase
+    BufferType = memoryview
+    FileType = IOBase
+    LongType = int
     StringTypes = (StringType,)
-
-BufferType = buffer
+    UnicodeType = str
+    XRangeType = range
 
 TupleType = tuple
 ListType = list
@@ -60,8 +64,6 @@ BuiltinFunctionType = type(len)
 BuiltinMethodType = type([].append)     # Same as BuiltinFunctionType
 
 ModuleType = type(sys)
-FileType = file
-XRangeType = xrange
 
 try:
     raise TypeError

--- a/编译器/编译器/Source/Lib/webbrowser.py
+++ b/编译器/编译器/Source/Lib/webbrowser.py
@@ -224,7 +224,7 @@ class UnixBrowser(BaseBrowser):
         cmdline = [self.name] + raise_opt + args
 
         if remote or self.background:
-            inout = file(os.devnull, "r+")
+            inout = open(os.devnull, "r+")
         else:
             # for TTY browsers, we need stdin/out
             inout = None
@@ -356,7 +356,7 @@ class Konqueror(BaseBrowser):
         else:
             action = "openURL"
 
-        devnull = file(os.devnull, "r+")
+        devnull = open(os.devnull, "r+")
         # if possible, put browser in separate process group, so
         # keyboard interrupts don't affect browser as well as Python
         setsid = getattr(os, 'setsid', None)


### PR DESCRIPTION
__file()__ was removed in Python 3 in favor of __open()__ and __raw_input()__ was removed in favor of __input()__.