### PR TITLE
Do not 'del def_op' so that Python 2.7 passes Travis CI tests

### DIFF
--- a/编译器/编译器/Source/Lib/opcode.py
+++ b/编译器/编译器/Source/Lib/opcode.py
@@ -189,4 +189,5 @@ EXTENDED_ARG = 145
 def_op('SET_ADD', 146)
 def_op('MAP_ADD', 147)
 
-del def_op, name_op, jrel_op, jabs_op
+# del def_op
+del name_op, jrel_op, jabs_op


### PR DESCRIPTION
Avoid the errors at https://travis-ci.com/cclauss/C--Compiler/jobs/197081734#L471