### PR TITLE
Fix raise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ group: travis_latest
 language: python
 cache: pip
 matrix:
-  allow_failures:
-    - python: 3.7
   include:
     - python: 2.7
     #- python: 3.5

--- a/编译器/编译器/Source/Lib/atexit.py
+++ b/编译器/编译器/Source/Lib/atexit.py
@@ -32,7 +32,10 @@ def _run_exitfuncs():
             exc_info = sys.exc_info()
 
     if exc_info is not None:
-        raise exc_info[0], exc_info[1], exc_info[2]
+        if sys.version_info[0] < 3:
+            raise exc_info[0], exc_info[1], exc_info[2]  # noqa: E999
+        else:
+            raise exc_info
 
 
 def register(func, *targs, **kargs):

--- a/编译器/编译器/Source/Lib/contextlib.py
+++ b/编译器/编译器/Source/Lib/contextlib.py
@@ -126,7 +126,10 @@ def nested(*managers):
             # Don't rely on sys.exc_info() still containing
             # the right information. Another exception may
             # have been raised and caught by an exit method
-            raise exc[0], exc[1], exc[2]
+            if sys.version_info[0] < 3:
+                raise exc[0], exc[1], exc[2]  # noqa: E999
+            else:
+                raise exc
 
 
 class closing(object):

--- a/编译器/编译器/Source/Lib/os.py
+++ b/编译器/编译器/Source/Lib/os.py
@@ -387,8 +387,18 @@ def _execvpe(file, args, env=None):
                 saved_exc = e
                 saved_tb = tb
     if saved_exc:
-        raise error, saved_exc, saved_tb
-    raise error, e, tb
+        if sys.version_info[0] < 3:
+            raise error, saved_exc, saved_tb  # noqa: E999
+        else:
+            ex = error(saved_exc)
+            ex.__traceback__ = saved_tb
+            raise ex
+    if sys.version_info[0] < 3:
+        raise error, e, tb  # noqa: E999
+    else:
+        ex = error(e)
+        ex.__traceback__ = tb
+        raise ex
 
 # Change environ to automatically call putenv() if it exists
 try:


### PR DESCRIPTION
https://portingguide.readthedocs.io/en/latest/exceptions.html#the-new-raise-syntax

Travis CI tests should now pass on both Python 2.7 and 3.7.

Future PRs should not be merged unless __both__ Travis tests are green.